### PR TITLE
Moved PP form validation to the form from the button

### DIFF
--- a/password_policy.module
+++ b/password_policy.module
@@ -46,7 +46,7 @@ function password_policy_form_user_form_alter(&$form, &$form_state) {
   );
 
   $form['actions']['submit']['#submit'][] = '_password_policy_user_profile_form_submit';
-  $form['actions']['submit']['#validate'][] = '_password_policy_user_profile_form_validate';
+  $form['#validate'][] = '_password_policy_user_profile_form_validate';
 }
 
 function password_policy_element_info_alter(array &$types) {


### PR DESCRIPTION
- Per https://www.drupal.org/node/2301335, form validation must be on the form as a whole, not the button to submit.