### PR TITLE
Remove hard-coded UUIDs from config yaml files

### DIFF
--- a/config/install/field.field.user.user.field_last_password_reset.yml
+++ b/config/install/field.field.user.user.field_last_password_reset.yml
@@ -1,4 +1,3 @@
-uuid: 0b1d8ccd-1d2c-48eb-9932-50ae2614a6cd
 langcode: en
 status: true
 dependencies:

--- a/config/install/field.field.user.user.field_password_expiration.yml
+++ b/config/install/field.field.user.user.field_password_expiration.yml
@@ -1,4 +1,3 @@
-uuid: 77dbe880-78e0-4df0-ac06-6d86338f2438
 langcode: en
 status: true
 dependencies:

--- a/config/install/field.storage.user.field_last_password_reset.yml
+++ b/config/install/field.storage.user.field_last_password_reset.yml
@@ -1,4 +1,3 @@
-uuid: bd6728d0-3411-4c87-9905-5cf0bf5a956b
 langcode: en
 status: true
 dependencies:

--- a/config/install/field.storage.user.field_password_expiration.yml
+++ b/config/install/field.storage.user.field_password_expiration.yml
@@ -1,4 +1,3 @@
-uuid: c76c0324-63c1-40bf-9d4a-7494cf91db80
 langcode: en
 status: true
 dependencies:


### PR DESCRIPTION
Per https://www.drupal.org/node/2087879:

> When using exported configuration it is important to remove the UUID from the configuration. Every piece of configuration is uniquely identified by this ID. If you would include this UUID in your module the ID would be the same for all sites that use your module, so it would not be unique any more. If you simply remove this line from the configuration Drupal will generate new UUIDs when your module is enabled, guaranteeing uniqueness.