### PR TITLE
Restores /admin/config/security page

### DIFF
--- a/password_policy.routing.yml
+++ b/password_policy.routing.yml
@@ -1,7 +1,7 @@
 password_policy.admin_index:
   path: '/admin/config/security'
   defaults:
-    _content: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
+    _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
     _title: 'Security'
   requirements:
     _permission: 'access administration pages'


### PR DESCRIPTION
Per https://www.drupal.org/node/2378809: password_policy.routing.yml should use _controller instead of _content to define the route