### PR TITLE
Fixes errors in ConstraintDelete form validaton and form title

### DIFF
--- a/src/Form/ConstraintDelete.php
+++ b/src/Form/ConstraintDelete.php
@@ -111,7 +111,9 @@ class ConstraintDelete extends ConfirmFormBase {
    * {@inheritdoc}
    */
   public function getQuestion($id = NULL, $cached_values = NULL) {
-    $context = $cached_values['contexts'][$id];
+    /** @var \Drupal\password_policy\Entity\PasswordPolicy $password_policy */
+    $password_policy = $cached_values['password_policy'];
+    $context = $password_policy->getConstraint($id);
     return $this->t('Are you sure you want to delete the @label constraint?', array(
       '@label' => $context['id'],
     ));
@@ -135,9 +137,6 @@ class ConstraintDelete extends ConfirmFormBase {
       'submit' => array(
         '#type' => 'submit',
         '#value' => $this->getConfirmText(),
-        '#validate' => array(
-          array($this, 'validate'),
-        ),
         '#submit' => array(
           array($this, 'submitForm'),
         ),


### PR DESCRIPTION
* Fixes errors in constraint delete form where ConstraintDelete throws PHP warnings because the form array defines #validate but the class does not include a validate method:
```
Warning: call_user_func_array() expects parameter 1 to be a valid callback, class 'Drupal\password_policy\Form\ConstraintDelete' does not have a method 'validate' in Drupal\Core\Form\FormValidator->executeValidateHandlers() (line 88 of [...]/core/lib/Drupal/Core/Form/FormValidator.php).
```
* Fixes a bug where the title of the ConstraintDelete form is missing the constraint title.