### PR TITLE
Issue #50: Updated to code to force user to change password if new ro…

### DIFF
--- a/password_policy.module
+++ b/password_policy.module
@@ -34,7 +34,7 @@ function password_policy_form_user_form_alter(&$form, &$form_state) {
     '#weight' => '4',
     '#prefix' => '<div id="password-policy-status">',
     '#suffix' => '</div>',
-    '#rows' => _password_policy_constraints_table($form, $form_state),
+    '#rows' => _password_policy_constraints_table($form, $form_state, TRUE),
   );
 
   //set ajax changes
@@ -73,15 +73,35 @@ function password_policy_check_constrains_password_confirm_process($element){
  * @param $form_state
  */
 function _password_policy_user_profile_form_validate(&$form, &$form_state) {
-  $roles = $form_state->getValue('roles');
 
+  return _password_policy_constraints_validate($form, $form_state);
+}
+
+/**
+ *  Validate password policty constraints and generate table if required.
+ * @param $form
+ * @param $form_state
+ * @param $generate_policy_table - set this to true if you want to generate policy table on user add/edit page
+ * @param $policies_table_rows - variable which holds applicable policies in array format.
+ */
+function _password_policy_constraints_validate(&$form, &$form_state, $generate_policy_table = FALSE, &$policies_table_rows = array()) {
+
+  $roles = $form_state->getValue('roles');
+  if (empty($roles)) {
+    //get if from $form; form state is always empty the first time.
+    $roles = $form['account']['roles']['#default_value'];
+  }
+  $roles = array_combine($roles, $roles);
+
+  $orignal_roles = $form['account']['roles']['#default_value'];
+  $orignal_roles = array_combine($orignal_roles, $orignal_roles);
+  
   //add user doesn't automatically register authenticated, so lets add it
   if (empty($roles)) {
     $roles = array('authenticated' => 'authenticated');
   }
 
   //run validation
-  $table_rows = array();
   $applicable_policies = array();
   $ids = array();
   foreach ($roles as $role_key => $role_enabled) {
@@ -97,6 +117,13 @@ function _password_policy_user_profile_form_validate(&$form, &$form_state) {
     }
   }
 
+  //Force failure
+  $force_failure = FALSE;
+
+  if ($roles != $orignal_roles && $form_state->getValue('pass') == '' && !empty($applicable_policies)) {
+    //new role has been added and applicable policies are available.
+    $force_failure = TRUE;
+  }
   //run validation
   $failed = FALSE;
 
@@ -112,30 +139,62 @@ function _password_policy_user_profile_form_validate(&$form, &$form_state) {
       $user_context_values[$user_context_field] = $form['account'][$user_context_field]['#default_value'];
     }
   }
-
-  //check policies
   foreach ($applicable_policies as $policy_id => $policy) {
     $policy_constraints = $policy->getConstraints();
 
     foreach ($policy_constraints as $constraint_id => $constraint) {
+
       $plugin_inst = \Drupal::service('plugin.manager.password_policy.password_constraint');
       $plugin_object = $plugin_inst->createInstance($constraint['id'], $constraint);
 
       //execute validation
       $validation = $plugin_object->validate($form_state->getValue('pass'), $user_context_values);
-      if (!$validation->isValid() and !$failed and $form_state->getValue('pass') != '') {
-        //throw error to ensure form will not submit
-        $failed = TRUE;
+      $status = "";
+      if ($generate_policy_table) {
+        if ($validation->isValid() && !$force_failure) {
+          $status = 'Pass';
+        }
+        else {
+          $message = $validation->getErrorMessage();
+          if (empty($message)) {
+            $message = t('New role was added or existing password policy changed. Please update your password.');
+          }
+          $status = 'Fail - ' . $message;
+          //throw error to ensure form will not submit
+          if (!$failed and $form_state->getValue('pass') != '') {
+            //set storage value since you cant throw errors here
+            $storage = $form_state->getStorage();
+            $storage['password_fails_policies'] = TRUE;
+            $form_state->setStorage($storage);
+            $failed = TRUE;
+          }
+        }
+        $table_row = array(
+          'policy' => $policy->label(),
+          'status' => $status,
+          'constraint' => $plugin_object->getSummary(),
+        );
+        $policies_table_rows[] = $table_row;
       }
-
+      else {
+        if (!$validation->isValid() and !$failed and $form_state->getValue('pass') != '') {
+          //throw error to ensure form will not submit
+          $failed = TRUE;
+        }
+        else if ($force_failure){
+          $failed = TRUE; 
+        }
+      }
     }
   }
-
-  if ($failed) {
+  if ($failed && !$generate_policy_table) {
     $form_state->setErrorByName('pass', 'The password does not satisfy the password policies');
   }
-
+  if ($generate_policy_table) {
+    return $policies_table_rows;
+  }
   return $failed;
+
 }
 
 /**
@@ -181,96 +240,11 @@ function _password_policy_check_constraints($form, $form_state) {
  */
 function _password_policy_constraints_table($form, $form_state) {
 
-  $roles = $form_state->getValue('roles');
+  $policies_table_rows = array();
+  _password_policy_constraints_validate($form, $form_state, TRUE, $policies_table_rows);
+  
+  return $policies_table_rows;
 
-  //check for add user edge case
-  if (!empty($roles[0])){
-    unset($roles[0]);
-  }
-
-  //add user doesn't automatically register authenticated, so lets add it
-  if (empty($roles)) {
-    $roles = array('authenticated' => 'authenticated');
-  }
-
-  //run validation
-  $table_rows = array();
-  $applicable_policies = array();
-  $ids = array();
-  foreach ($roles as $role_key => $role_enabled) {
-    if ($role_enabled) {
-      $role_map = array('roles.'.$role_key => $role_key);
-      $role_policies = entity_load_multiple_by_properties('password_policy', $role_map);
-      foreach ($role_policies as $policy) {
-        if (!in_array($policy->id(), $ids)) {
-          $applicable_policies[] = $policy;
-          $ids[] = $policy->id();
-        }
-      }
-    }
-  }
-
-  //run validation
-  $failed = FALSE;
-
-  //process user context
-  //TODO - Turn this into configuration
-  $user_context_fields = array('mail', 'name', 'uid');
-  $user_context_values = array();
-
-  foreach ($user_context_fields as $user_context_field) {
-    $user_context_values[$user_context_field] = $form_state->getValue($user_context_field);
-
-    //check default value
-    if ($user_context_field == 'uid') {
-      $user_context_values[$user_context_field] = \Drupal::routeMatch()->getRawParameter('user');
-    }
-    if (empty($user_context_values[$user_context_field]) and (!empty($form['account'][$user_context_field]['#default_value']))) {
-      $user_context_values[$user_context_field] = $form['account'][$user_context_field]['#default_value'];
-    }
-  }
-
-  //check policies
-  foreach ($applicable_policies as $policy_id => $policy) {
-    $policy_constraints = $policy->getConstraints();
-
-    foreach ($policy_constraints as $constraint_id => $constraint) {
-
-
-      $plugin_inst = \Drupal::service('plugin.manager.password_policy.password_constraint');
-
-      $plugin_object = $plugin_inst->createInstance($constraint['id'], $constraint);
-
-      //execute validation
-      $validation = $plugin_object->validate($form_state->getValue('pass'), $user_context_values);
-
-      if ($validation->isValid()) {
-        $status = 'Pass';
-      }
-      else {
-        $status = 'Fail - ' . $validation->getErrorMessage();
-        //throw error to ensure form will not submit
-        if (!$failed and $form_state->getValue('pass') != '') {
-          //set storage value since you cant throw errors here
-          $storage = $form_state->getStorage();
-          $storage['password_fails_policies'] = TRUE;
-          $form_state->setStorage($storage);
-          $failed = TRUE;
-        }
-      }
-
-      $table_row = array(
-        'policy' => $policy->label(),
-        'status' => $status,
-        'constraint' => $plugin_object->getSummary(),
-      );
-      $table_rows[] = $table_row;
-
-    }
-  }
-
-  //if no role, show default message
-  return $table_rows;
 }
 
 /**


### PR DESCRIPTION
Updated to code to force user to change password if new role has been added with policy restrictions.

Following additions were done -

1. Moved validation code to a common function. Earlier it was replicated in _validate and _table_rows functions.
2. Updated code to force user to change password if new role is being added with applicable policies.
3. Added code to load policies currently when edit user page is visited for the first time. (form state is always empty)